### PR TITLE
Remove uses of Spree.t

### DIFF
--- a/app/models/spree/calculator/tiered_quantity_percent.rb
+++ b/app/models/spree/calculator/tiered_quantity_percent.rb
@@ -19,7 +19,7 @@ module Spree
     validate :preferred_tiers_content
 
     def self.description
-      Spree.t(:quantity_tiered_percent)
+      I18n.t("spree.quantity_tiered_percent")
     end
 
     def compute(object)

--- a/app/overrides/spree/admin/products/_form/add_bulk_discount_field.html.erb.deface
+++ b/app/overrides/spree/admin/products/_form/add_bulk_discount_field.html.erb.deface
@@ -2,6 +2,6 @@
 
 <%= f.field_container :bulk_discount do %>
     <%= f.label :bulk_discount, "Bulk Discount" %>
-    <%= f.collection_select(:bulk_discount_id, Spree::BulkDiscount.all, :id, :name, {:include_blank => Spree.t('match_choices.none')}, {:class => 'select2'}) %>
+    <%= f.collection_select(:bulk_discount_id, Spree::BulkDiscount.all, :id, :name, {:include_blank => I18n.t('spree.match_choices.none')}, {:class => 'select2'}) %>
     <%= f.error_message_on :bulk_discount %>
 <% end %>

--- a/app/views/spree/admin/bulk_discounts/_calculators_with_custom_fields.html.erb
+++ b/app/views/spree/admin/bulk_discounts/_calculators_with_custom_fields.html.erb
@@ -1,12 +1,12 @@
 <div class="calculator-fields row">
   <div class="field alpha four columns">
     <% field_name = "#{param_prefix}[calculator_type]" %>
-    <%= label_tag field_name, Spree.t(:calculator) %>
+    <%= label_tag field_name, I18n.t("spree.calculator") %>
     <%= select_tag field_name,
                    options_from_collection_for_select(calculators, :to_s, :description, bulk_discount.calculator.type),
                    :class => 'type-select select2 fullwidth' %>
     <% if bulk_discount.calculator.respond_to?(:preferences) %>
-        <span class="warning info"><%= Spree.t(:calculator_settings_warning) %></span>
+        <span class="warning info"><%= I18n.t("spree.calculator_settings_warning") %></span>
     <% end %>
   </div>
 

--- a/app/views/spree/admin/bulk_discounts/_form.html.erb
+++ b/app/views/spree/admin/bulk_discounts/_form.html.erb
@@ -1,11 +1,11 @@
 <div data-hook="admin_tax_rate_form_fields">
   <div class="alpha twelve columns">
     <fieldset data-hook="tax_rates" class=" no-border-bottom">
-      <legend align="center"><%= Spree.t(:general_settings) %></legend>
+      <legend align="center"><%= I18n.t("spree.general_settings") %></legend>
 
       <div class="alpha nine columns">
         <div data-hook="name" class="field">
-          <%= f.label :name, Spree.t(:name) %>
+          <%= f.label :name, I18n.t("spree.name") %>
           <%= f.text_field :name, :class => 'fullwidth' %>
         </div>
       </div>

--- a/app/views/spree/admin/bulk_discounts/calculators/_default_fields.html.erb
+++ b/app/views/spree/admin/bulk_discounts/calculators/_default_fields.html.erb
@@ -1,6 +1,6 @@
 <% calculator.preferences.keys.map do |key| %>
     <% field_name = "#{prefix}[calculator_attributes][preferred_#{key}]" %>
-    <%= label_tag field_name, Spree.t(key.to_s) %>
+    <%= label_tag field_name, I18n.t("spree.#{key.to_s}") %>
     <%= preference_field_tag(
             field_name,
             calculator.get_preference(key),

--- a/app/views/spree/admin/bulk_discounts/calculators/tiered_quantity_percent/_fields.html.erb
+++ b/app/views/spree/admin/bulk_discounts/calculators/tiered_quantity_percent/_fields.html.erb
@@ -1,14 +1,14 @@
 <%= label_tag "#{prefix}[calculator_attributes][preferred_base_percent]",
-              Spree.t(:base_percent) %>
+              I18n.t("spree.base_percent") %>
 <%= preference_field_tag(
         "#{prefix}[calculator_attributes][preferred_base_percent]",
         calculator.preferred_base_percent,
         type: calculator.preference_type(:base_percent)) %>
 
-<%= label_tag nil, Spree.t(:tiers) %>
+<%= label_tag nil, I18n.t("spree.tiers") %>
 <%= content_tag :div, nil, class: "js-tiers-quantity", data: {
     'original-tiers' => Hash[calculator.preferred_tiers.sort],
     'form-prefix' => prefix,
     'calculator' => 'tiered_quantity_percent'
 } %>
-<button class="fa fa-plus button js-add-tier"><%= Spree.t(:add) %></button>
+<button class="fa fa-plus button js-add-tier"><%= I18n.t("spree.add") %></button>

--- a/app/views/spree/admin/bulk_discounts/edit.html.erb
+++ b/app/views/spree/admin/bulk_discounts/edit.html.erb
@@ -1,10 +1,10 @@
 <% content_for :page_title do %>
-    <%= Spree.t(:editing_bulk_discount) %>
+    <%= I18n.t("spree.editing_bulk_discount") %>
 <% end %>
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to Spree.t(:back_to_bulk_discounts_list), spree.admin_bulk_discounts_path, :icon => 'arrow-left' %>
+      <%= button_link_to I18n.t("spree.back_to_bulk_discounts_list"), spree.admin_bulk_discounts_path, :icon => 'arrow-left' %>
     </li>
 <% end %>
 

--- a/app/views/spree/admin/bulk_discounts/index.html.erb
+++ b/app/views/spree/admin/bulk_discounts/index.html.erb
@@ -1,10 +1,10 @@
 <% content_for :page_title do %>
-    <%= Spree.t(:bulk_discounts) %>
+    <%= I18n.t("spree.bulk_discounts") %>
 <% end %>
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to Spree.t(:new_bulk_discount), new_object_url, :icon => 'plus' %>
+      <%= button_link_to I18n.t("spree.new_bulk_discount"), new_object_url, :icon => 'plus' %>
     </li>
 <% end %>
 
@@ -12,7 +12,7 @@
     <table class="index">
       <thead>
         <tr data-hook="rate_header">
-          <th><%= Spree.t(:name) %></th>
+          <th><%= I18n.t("spree.name") %></th>
           <th class="actions"></th>
         </tr>
       </thead>
@@ -30,7 +30,7 @@
     </table>
 <% else %>
     <div class="alpha twelve columns no-objects-found">
-      <%= Spree.t(:no_resource_found, resource: I18n.t(:other, scope: 'activerecord.models.spree/bulk_discount')) %>,
-      <%= link_to Spree.t(:add_one), spree.new_admin_bulk_discount_path %>!
+      <%= I18n.t("spree.no_resource_found", resource: I18n.t(:other, scope: 'activerecord.models.I18n/bulk_discount')) %>,
+      <%= link_to I18n.t("spree.add_one"), spree.new_admin_bulk_discount_path %>!
     </div>
 <% end %>


### PR DESCRIPTION
In preparation for upgrading to Solidus 3, we need to remove the uses of Spree.t and Spree.translate.