### PR TITLE
Remove use of .calculators method

### DIFF
--- a/app/controllers/spree/admin/bulk_discounts_controller.rb
+++ b/app/controllers/spree/admin/bulk_discounts_controller.rb
@@ -6,7 +6,7 @@ module Spree
       private
 
       def load_calculators
-        @calculators = BulkDiscount.calculators.sort_by(&:name)
+        @calculators = Rails.application.config.spree.calculators.bulk_discounts.sort_by(&:name)
       end
     end
   end


### PR DESCRIPTION
This method has been deprecated and will be removed in Solidus 3