### PR TITLE
Fix broken /bulk_discounts page

### DIFF
--- a/app/views/spree/admin/bulk_discounts/_form.html.erb
+++ b/app/views/spree/admin/bulk_discounts/_form.html.erb
@@ -21,5 +21,5 @@
   <div class="clear"></div>
 
   <%= render partial: 'spree/admin/bulk_discounts/calculators_with_custom_fields',
-      locals: { calculators: Spree::BulkDiscount.calculators, bulk_discount: f.object, param_prefix: 'bulk_discount' } %>
+      locals: { calculators: Rails.application.config.spree.calculators.bulk_discounts.sort_by(&:name), bulk_discount: f.object, param_prefix: 'bulk_discount' } %>
 </div>

--- a/app/views/spree/admin/bulk_discounts/calculators/tiered_quantity_percent/_fields.html.erb
+++ b/app/views/spree/admin/bulk_discounts/calculators/tiered_quantity_percent/_fields.html.erb
@@ -1,9 +1,6 @@
-<%= label_tag "#{prefix}[calculator_attributes][preferred_base_percent]",
-              I18n.t("spree.base_percent") %>
-<%= preference_field_tag(
-        "#{prefix}[calculator_attributes][preferred_base_percent]",
-        calculator.preferred_base_percent,
-        type: calculator.preference_type(:base_percent)) %>
+<%= render "spree/admin/shared/preference_fields/#{calculator.preference_type(:base_percent)}",
+  name: "#{prefix}[calculator_attributes][preferred_base_percent]",
+  value: calculator.preferred_base_percent, label: I18n.t("spree.base_percent") %>
 
 <%= label_tag nil, I18n.t("spree.tiers") %>
 <%= content_tag :div, nil, class: "js-tiers-quantity", data: {

--- a/app/views/spree/admin/bulk_discounts/edit.html.erb
+++ b/app/views/spree/admin/bulk_discounts/edit.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to I18n.t("spree.back_to_bulk_discounts_list"), spree.admin_bulk_discounts_path, :icon => 'arrow-left' %>
+      <%= button_to I18n.t("spree.back_to_bulk_discounts_list"), spree.admin_bulk_discounts_path, :icon => 'arrow-left' %>
     </li>
 <% end %>
 

--- a/app/views/spree/admin/bulk_discounts/index.html.erb
+++ b/app/views/spree/admin/bulk_discounts/index.html.erb
@@ -4,7 +4,7 @@
 
 <% content_for :page_actions do %>
     <li>
-      <%= button_link_to I18n.t("spree.new_bulk_discount"), new_object_url, :icon => 'plus' %>
+      <%= button_to I18n.t("spree.new_bulk_discount"), new_object_url, :icon => 'plus' %>
     </li>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,3 +15,4 @@ en:
           please_try_again: "Please try again"
       tab:
         bulk_discounts: "Bulk Discounts"
+    quantity_tiered_percent: "Quantity Tiered Percent"


### PR DESCRIPTION
This page has old deprecated code on it. It's not used very often so it was only just discovered. I tested this my updating the files manually in the PW code base. It's not the prettiest page but I want to get it rendering and the updating works, so this is suffice until we decide if we want to style it better.

Before
<img width="1551" alt="Screenshot 2024-01-22 at 12 46 52 PM" src="https://github.com/pervino/solidus_bulk_discounts/assets/26180285/edbc6c00-d7cd-43a6-9e0b-594ac810563b">

After
<img width="1591" alt="Screenshot 2024-01-22 at 12 47 42 PM" src="https://github.com/pervino/solidus_bulk_discounts/assets/26180285/b02829ec-18c2-4371-9332-f46b3315aa1d">

<img width="1577" alt="Screenshot 2024-01-22 at 12 46 34 PM" src="https://github.com/pervino/solidus_bulk_discounts/assets/26180285/5652de97-203d-4066-9ae0-2867492b234e">
